### PR TITLE
Fix TypeScript parser:

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -39,7 +39,13 @@ function buildPath(cx) {
 
 function functionType(node, cx) {
   var type = "fn(";
-  var args = node.parameterList.parameters;
+  var args;
+  // In TypeScript 1.0 constructor parameters are wrapped in callSignature
+  if(node.callSignature){
+    args = node.callSignature.parameterList.parameters;
+  } else {
+    args = node.parameterList.parameters;
+  }
   for (var i = 0, e = args.childCount(); i < e; ++i) {
     var arg = args.childAt(i);
     if (!arg.identifier) continue;
@@ -50,21 +56,47 @@ function functionType(node, cx) {
   }
   type += ")";
   var ret = node.typeAnnotation && node.typeAnnotation.type;
-  if (ret && ret.kind() != nt.VoidKeyword) // FIXME filter out void
-    type += " -> " + flat(ret, {enter: "!ret", prev: cx});
+  if (ret && ret.kind() != nt.VoidKeyword) {// FIXME filter out void
+    // return instance for QualifiedName and IdentifierName
+    if (ret.kind() === nt.QualifiedName || ret.kind() === nt.IdentifierName) {
+      type += " -> +";
+    } else {
+      type += " -> ";
+    }
+    type += flat(ret, {enter: "!ret", prev: cx});
+  }
   return type;
 }
 
-function addToObj(data, identifier, val) {
-  var known = data[name];
+function getLeftMostIdentifierParts(identifier) {
+  if (identifier.left && identifier.left.left) return getLeftMostIdentifierParts(identifier.left);	
+  if (identifier.left) return { text: identifier.left.text(), rest: identifier.right};
+  return { text: identifier.text(), rest: identifier.right};
+}
+
+function addToObj(data, identifier, val) {  
+  //Handle the case when modules declared "declare module moduleName.submoduleName"
+  if (identifier.left) {
+    var leftPart = identifier.left;
+    identifier = identifier.right;
+    while (leftPart) {
+      var indentifierParts = getLeftMostIdentifierParts(leftPart);
+      data = data[indentifierParts.text];
+      leftPart = indentifierParts.rest;
+    }
+  }
   var name = identifier.text();
+  var known = data[name];
   if (/^".*"$/.test(name)) name = name.slice(1, name.length - 1);
   if (known) {
     if (typeof known != "string" && typeof val == "string" && !known["!type"]) {
       known["!type"] = val;
-    } else if (typeof known == "string" && typeof val != "string") {
-      data[name] = val;
-      val["!type"] = known;
+    } else if (typeof known === "object" && typeof val === "object") {
+        for (var prop in val) {
+          known[prop] = val[prop];
+        }
+    } else {
+        data[name] = val;
     }
   } else {
     data[name] = val;
@@ -102,6 +134,8 @@ function objType(list, cx, cls) {
     case nt.ClassDeclaration:
       var inner = {};
       inner.prototype = objType(field.classElements, cx, inner);
+      //in case no constructor defined create a default one
+      if (!inner["!type"]) inner["!type"] = "fn()";
       addToObj(target, field.identifier, inner);
       break;
     case nt.PropertySignature:
@@ -131,6 +165,7 @@ function objType(list, cx, cls) {
     case nt.IndexSignature:
     case nt.SemicolonToken:
     case nt.EmptyStatement:
+    case nt.IndexMemberDeclaration:
       break;
     default:
       throw new Error("Unknown field type: " + nt[field.kind()]);
@@ -162,6 +197,7 @@ function walk(node, cx) {
     return "bool";
   case nt.AnyKeyword:
   case nt.VoidKeyword:
+  case nt.GenericType:
     return "?";
   case nt.TypeQuery:
     return walk(node.name);


### PR DESCRIPTION
- create default constructor for classes if not defined
- ignore IndexMemberDeclaration
- handle GenericType
- support module and class with same name on same level
- fix constructor parameters parsing
- handle modules declared "declare module moduleName.submoduleName"
